### PR TITLE
Detect Potential Regex Based DoS

### DIFF
--- a/lib/queries.js
+++ b/lib/queries.js
@@ -257,4 +257,12 @@ module.exports.Sinks = [{
 	name: 'Response spliting',
 	test: tests.object(ast.ce(ast.me(ast.ne(ast.req('cookies'))))),
 	handle: handlers.index(1)
+}, { // RegExp
+	name: 'RegExp',
+	test: tests.object(ast.ce('RegExp')),
+	handle: handlers.index(0)
+}, { // regex
+	name: 'regex',
+	test: tests.object(ast.ce(ast.me('regex'))),
+	handle: handlers.index(0)
 }];

--- a/vulns/regex.js
+++ b/vulns/regex.js
@@ -1,0 +1,5 @@
+/* {"length": 3, "process": true} */
+
+var regex = RegExp(process.argv[2]);
+regex.compile(process.argv[3]);
+regex.test(process.argv[4]);


### PR DESCRIPTION
Catch when harmful data is used for Regex. This problem mainly only happens for the test method but it would be safe to catch when a regex is being set in case that regex is passed around (to an external library or something else that we deem safe).
